### PR TITLE
Add marvel authentication

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,3 @@
+# Enable auto-env through the sdkman_auto_env config
+# Add key=value pairs of SDKs to use below
+java=17.0.2-tem

--- a/README.md
+++ b/README.md
@@ -15,13 +15,22 @@ These instructions will get you a copy of the project up and running on your
 local machine for development and testing purposes. See deployment for notes on
 how to deploy the project on a live system.
 
+This project contains multiple modules:
+
+- [marvel-client](./marvel-client/README.md) - responsible for the communication
+with Marvel's API.
+- [marvel-data](./marvel-data/README.md) - responsible for the persistence &
+management of the data served by the project.
+- [marvel-web](./marvel-web/README.md) - responsible to serve the web
+application of this project.
+
 ### Prerequisites
 
 To run the project you need to install the following:
 
 - JDK 17 or newer
+- Gradle 7.4.x or newer
 - Docker
-
 
 ### Building the application
 

--- a/marvel-client/README.md
+++ b/marvel-client/README.md
@@ -1,0 +1,40 @@
+# marvel-client
+
+The `marvel-client` module is responsible for the communication between the
+project and the [Marvel API](https://developer.marvel.com/docs).
+
+In order to communicate with Marvel's API you need your public and private keys
+exposed either by adding them to the `application.yml` file as follow:
+
+```yml
+marvel:
+  api:
+    public_key: "MY_PUBLIC_KEY"
+    private_key: "MY_PRIVATE_KEY"
+```
+
+Or by exposing them over environment variables:
+```shell
+expose MARVEL_API_PUBLIC_KEY=MY_PUBLIC_KEY
+expose MARVEL_API_PRIVATE_KEY=MY_PRIVATE_KEY
+```
+
+Once both are set, you can use any of the available clients
+(e.g. `MarvelCharacterClient`) and the `HashGenerator` to call the api.
+
+For example:
+
+```kotlin
+val client = Retrofit.Builder()
+    .client(OkHttpClient())
+    .baseUrl("MARVEL_API_URL")
+    .addConverterFactory(JacksonConverterFactory.create(objectMapper))
+    .build()
+    .create(MarvelCharacterClient::class.java)
+
+val timestamp = Instant.now().epochSecond
+val hash = HashGenerator.generate(timestamp)
+
+val characters =
+    client.getCharacters(timestamp, HashGenerator.publicKey, hash)
+```

--- a/marvel-client/src/main/kotlin/com/yonatankarp/marvel/clients/MarvelCharacterClient.kt
+++ b/marvel-client/src/main/kotlin/com/yonatankarp/marvel/clients/MarvelCharacterClient.kt
@@ -1,4 +1,4 @@
-package com.yonatankarp.marvel.services
+package com.yonatankarp.marvel.clients
 
 import com.yonatankarp.marvel.model.Character
 import com.yonatankarp.marvel.model.Comics

--- a/marvel-client/src/main/kotlin/com/yonatankarp/marvel/utils/authentication/HashGenerator.kt
+++ b/marvel-client/src/main/kotlin/com/yonatankarp/marvel/utils/authentication/HashGenerator.kt
@@ -1,0 +1,16 @@
+package com.yonatankarp.marvel.utils.authentication
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import org.springframework.util.DigestUtils
+
+@Component
+class HashGenerator(
+    @Value("\${marvel.api.public_key}") val publicKey: String,
+    @Value("\${marvel.api.private_key}") private val privateKey: String
+) {
+    fun generate(ts: Long): String {
+        val password = ts.toString() + privateKey + publicKey
+        return DigestUtils.md5DigestAsHex(password.toByteArray())
+    }
+}

--- a/marvel-client/src/main/resources/application.yml
+++ b/marvel-client/src/main/resources/application.yml
@@ -1,0 +1,5 @@
+marvel:
+  api:
+    url: "https://gateway.marvel.com"
+    publickey: "${marvel-public-key}:change-me"
+    privatekey: "${marvel-private-key}:change-me"

--- a/marvel-client/src/test/kotlin/com/yonatankarp/marvel/clients/AbstractIntegrationTest.kt
+++ b/marvel-client/src/test/kotlin/com/yonatankarp/marvel/clients/AbstractIntegrationTest.kt
@@ -1,4 +1,4 @@
-package com.yonatankarp.marvel.services
+package com.yonatankarp.marvel.clients
 
 import java.io.File
 

--- a/marvel-client/src/test/kotlin/com/yonatankarp/marvel/clients/MarvelCharacterClientIntegrationTest.kt
+++ b/marvel-client/src/test/kotlin/com/yonatankarp/marvel/clients/MarvelCharacterClientIntegrationTest.kt
@@ -1,4 +1,4 @@
-package com.yonatankarp.marvel.services
+package com.yonatankarp.marvel.clients
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module

--- a/marvel-client/src/test/kotlin/com/yonatankarp/marvel/clients/MarvelCharacterClientTest.kt
+++ b/marvel-client/src/test/kotlin/com/yonatankarp/marvel/clients/MarvelCharacterClientTest.kt
@@ -1,4 +1,4 @@
-package com.yonatankarp.marvel.services
+package com.yonatankarp.marvel.clients
 
 import com.yonatankarp.marvel.model.common.MarvelResponse
 import okhttp3.OkHttpClient

--- a/marvel-client/src/test/kotlin/com/yonatankarp/marvel/utils/authentication/HashGeneratorTest.kt
+++ b/marvel-client/src/test/kotlin/com/yonatankarp/marvel/utils/authentication/HashGeneratorTest.kt
@@ -1,0 +1,28 @@
+package com.yonatankarp.marvel.utils.authentication
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+@Suppress("kotlin:S100")
+internal class HashGeneratorTest {
+
+    private val generator: HashGenerator = HashGenerator(PUBLIC_KEY, PRIVATE_KEY)
+
+    @Test
+    fun `should generate correct hash code`() {
+        // Given
+        val timestamp = 1L
+
+        // When
+        val actual = generator.generate(timestamp)
+
+        // Then
+        val expected = "852d790bf3313eeecf72b436795fa4d9"
+        assertEquals(expected, actual)
+    }
+
+    companion object {
+        private const val PUBLIC_KEY = "public-key"
+        private const val PRIVATE_KEY = "private-key"
+    }
+}

--- a/marvel-data/README.md
+++ b/marvel-data/README.md
@@ -1,0 +1,4 @@
+# marvel-data
+
+The `marvel-data` module is responsible for the persistence &management of
+the data served by the project.

--- a/marvel-web/README.md
+++ b/marvel-web/README.md
@@ -1,0 +1,4 @@
+# marvel-web
+
+The `marvel-web` module is responsible to serve the web application of this
+project.


### PR DESCRIPTION
# Purpose

This PR includes 3 parts:

1. Rename the packages `services` inside `marvel-client` to `client` to reflect the true meaning of it content.
2. #21
3. #29

# Types of changes

- [ ] Bugfix
- [x] Feature
- [x] Refactoring

# Checklist

- [x] Documentation is updated
- [ ] No new tests needed
